### PR TITLE
adds support for filter option to subscriptions.listByAccount

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -32,7 +32,7 @@
         t.request(utils.addParams(routes.accounts.notes, {account_code: accountcode}), callback);
       }
     }
-    
+
     //https://dev.recurly.com/docs/list-an-accounts-adjustments
     this.adjustments = {
       list: function(accountcode, callback){
@@ -48,7 +48,7 @@
         t.request(utils.addParams(routes.adjustments.remove, {uuid: uuid}), callback);
       }
     }
-    
+
 	//https://dev.recurly.com/docs/lookup-an-accounts-billing-info
     this.billingInfo = {
       update: function(accountcode, details, callback){
@@ -96,7 +96,7 @@
         t.request(utils.addParams(routes.couponRedemption.getByInvoice, {invoice_number: invoicenumber}), callback)
       }
     }
-    
+
     //https://dev.recurly.com/docs/list-invoices
     this.invoices = {
       list: function(filter, callback){
@@ -167,10 +167,10 @@
       },
       update: function(plancode, addoncode, details, callback){
         t.request(utils.addParams(
-          routes.planAddons.update, 
+          routes.planAddons.update,
           { plan_code: plancode,
             add_on_code: addoncode
-          }), 
+          }),
         callback, js2xmlparser('add_on', details));
       },
       remove: function(plancode, addoncode, callback){
@@ -183,9 +183,12 @@
       list: function(filter, callback){
         t.request(utils.addQueryParams(routes.subscriptions.list, filter), callback);
       },
-      listByAccount: function(accountcode, callback){
-        t.request(utils.addParams(routes.subscriptions.listByAccount, {account_code: accountcode}), callback);
-
+      listByAccount: function(accountcode, filter, callback){
+        t.request(
+          utils.addParams(
+            utils.addQueryParams(routes.subscriptions.listByAccount, filter)
+            , {account_code: accountcode})
+          , callback)
       },
       get: function(uuid, callback){
         t.request(utils.addParams(routes.subscriptions.get, {uuid: uuid}), callback);


### PR DESCRIPTION
The Recurly API should provide a filter parameter to `subscriptions.listByAccount`, this just enables the functionality in `node-recurly`.  See https://dev.recurly.com/docs/list-subscriptions.
