### PR TITLE
fix bad content-length on unicode input

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,7 @@
         var endpoint = route[0];
         var method = route[1];
         var that = this;
+        var len = (data) ? Buffer.from(data).length : 0;
         var options = {
           host: config.RECURLY_HOST,
           port: 443,
@@ -21,7 +22,7 @@
           headers: {
             Authorization: "Basic " + (new Buffer(config.API_KEY)).toString('base64'),
             Accept: 'application/xml',
-            'Content-Length': (data) ? data.length : 0,
+            'Content-Length': len,
             'User-Agent': "node-recurly/" + pjson.version
           }
         };


### PR DESCRIPTION
Content length was set from simple string length, meaning that resulting xml documents with unicode content were truncated. Fixed to use actual size in bytes.