### PR TITLE
Add utf-8 to ContentType header

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,13 +21,13 @@
           headers: {
             Authorization: "Basic " + (new Buffer(config.API_KEY)).toString('base64'),
             Accept: 'application/xml',
-            'Content-Length': (data) ? data.length : 0,
+            'Content-Length': (data) ? Buffer.byteLength(data, 'utf-8') : 0,
             'User-Agent': "node-recurly/" + pjson.version
           }
         };
 
         if (method.toLowerCase() === 'post' || method.toLowerCase() === 'put') {
-          options.headers['Content-Type'] = 'application/xml';
+          options.headers['Content-Type'] = 'application/xml; charset=utf-8';
           that.debug(data);
         }
         that.debug(options);


### PR DESCRIPTION
This is documented here: https://dev.recurly.com/docs/getting-started#section-content-type-header

Also fixes the issue with `Content-Length` header for handling unicode characters (slightly different but equivalent to that in https://github.com/cgerrior/node-recurly/pull/7). 
